### PR TITLE
[feat] 홈 뷰 엠플리튜드 이벤트 코드 및 특정 뷰 -> 필터링 이탈, 완료율 이벤트 코드를 심기

### DIFF
--- a/app/src/main/java/com/sopt/geonppang/presentation/bakeryList/BakeryListFragment.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/bakeryList/BakeryListFragment.kt
@@ -48,7 +48,7 @@ class BakeryListFragment :
         }
 
         binding.ivSearch.setOnClickListener {
-            startActivity(Intent(requireActivity(), SearchActivity::class.java))
+            moveToSearch()
         }
 
         binding.ivBakeryListFilter.setOnClickListener {
@@ -80,6 +80,12 @@ class BakeryListFragment :
         startActivity(intent)
     }
 
+    private fun moveToSearch() {
+        val intent = Intent(requireActivity(), SearchActivity::class.java)
+        intent.putExtra(VIEW_TO_VIEW, BAKERY_LIST_TO_SEARCH)
+        startActivity(intent)
+    }
+
     private fun moveToFilter() {
         val intent = Intent(requireContext(), FilterSettingActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_NO_HISTORY
@@ -107,5 +113,7 @@ class BakeryListFragment :
     companion object {
         const val BAKERY_ID = "bakeryId"
         const val FILTER_INFO = "filterInfo"
+        const val VIEW_TO_VIEW = "viewToView"
+        const val BAKERY_LIST_TO_SEARCH = "bakeryListToSearch"
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/filterSetting/FilterSettingActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/filterSetting/FilterSettingActivity.kt
@@ -8,6 +8,7 @@ import com.sopt.geonppang.R
 import com.sopt.geonppang.databinding.ActivityFilterBinding
 import com.sopt.geonppang.presentation.MainActivity
 import com.sopt.geonppang.presentation.type.FilterInfoType
+import com.sopt.geonppang.util.AmplitudeUtils
 import com.sopt.geonppang.util.binding.BindingActivity
 import com.sopt.geonppang.util.setInvisibility
 import dagger.hilt.android.AndroidEntryPoint
@@ -48,6 +49,7 @@ class FilterSettingActivity : BindingActivity<ActivityFilterBinding>(R.layout.ac
         binding.ivFilterArrowLeft.setOnClickListener {
             when (binding.vpFilterContainer.currentItem) {
                 0 -> {
+                    trackDeviationFromFilterView()
                     finish()
                 }
 
@@ -64,6 +66,7 @@ class FilterSettingActivity : BindingActivity<ActivityFilterBinding>(R.layout.ac
 
                     when (viewModel.previousActivity.value) {
                         FilterInfoType.BAKERYLIST -> {
+                            AmplitudeUtils.trackEvent(COMPLETE_FILTER_LIST)
                             val intent = Intent(this, MainActivity::class.java)
                             intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
                             intent.putExtra(BAKERY_LIST_FRAGMENT, BAKERY_LIST_FRAGMENT)
@@ -71,6 +74,7 @@ class FilterSettingActivity : BindingActivity<ActivityFilterBinding>(R.layout.ac
                         }
 
                         FilterInfoType.MYPAGE -> {
+                            AmplitudeUtils.trackEvent(COMPLETE_FILTER_MY)
                             val intent = Intent(this, MainActivity::class.java)
                             intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
                             intent.putExtra(MYPAGE_FRAGMENT, MYPAGE_FRAGMENT)
@@ -78,6 +82,7 @@ class FilterSettingActivity : BindingActivity<ActivityFilterBinding>(R.layout.ac
                         }
 
                         FilterInfoType.HOME -> {
+                            AmplitudeUtils.trackEvent(COMPLETE_FILTER_HOME)
                             val intent = Intent(this, MainActivity::class.java)
                             intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
                             startActivity(intent)
@@ -147,10 +152,34 @@ class FilterSettingActivity : BindingActivity<ActivityFilterBinding>(R.layout.ac
         return String.format(PAGE_FORMAT, currentPage)
     }
 
+    private fun trackDeviationFromFilterView() {
+        when (viewModel.previousActivity.value) {
+            FilterInfoType.HOME -> {
+                AmplitudeUtils.trackEvent(CLICK_FILTER_BACK_HOME)
+            }
+
+            FilterInfoType.BAKERYLIST -> {
+                AmplitudeUtils.trackEvent(CLICK_FILTER_BACK_LIST)
+            }
+
+            FilterInfoType.MYPAGE -> {
+                AmplitudeUtils.trackEvent(CLICK_FILTER_BACK_MY)
+            }
+
+            else -> {}
+        }
+    }
+
     companion object {
         const val FILTER_INFO = "filterInfo"
         const val MYPAGE_FRAGMENT = "MyPageFragment"
         const val BAKERY_LIST_FRAGMENT = "BakeryListFragment"
         const val PAGE_FORMAT = "%d/3"
+        const val CLICK_FILTER_BACK_HOME = "click_filter_back_home"
+        const val CLICK_FILTER_BACK_LIST = "click_filterback_list"
+        const val CLICK_FILTER_BACK_MY = "click_filter_back_mypage"
+        const val COMPLETE_FILTER_HOME = "complete_filter_home"
+        const val COMPLETE_FILTER_LIST = "complete_filter_list"
+        const val COMPLETE_FILTER_MY = "complete_filter_mypage"
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/home/BestBakeryAdapter.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/home/BestBakeryAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.sopt.geonppang.databinding.ItemHomeBestBakeryBinding
 import com.sopt.geonppang.domain.model.BestBakery
+import com.sopt.geonppang.util.AmplitudeUtils
 import com.sopt.geonppang.util.ItemDiffCallback
 import com.sopt.geonppang.util.setVisibility
 
@@ -29,6 +30,7 @@ class BestBakeryAdapter(
             binding.executePendingBindings()
 
             binding.root.setOnClickListener {
+                AmplitudeUtils.trackEvent(CLICK_RECOMMEND_STORE)
                 moveToDetail(MAIN, bakery.bakeryId)
             }
 
@@ -48,5 +50,6 @@ class BestBakeryAdapter(
 
     companion object {
         const val MAIN = "mainActivity"
+        const val CLICK_RECOMMEND_STORE = "click_recommend_store"
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/home/BestReviewAdapter.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/home/BestReviewAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.sopt.geonppang.databinding.ItemHomeBestReviewBinding
 import com.sopt.geonppang.domain.model.BestReview
+import com.sopt.geonppang.util.AmplitudeUtils
 import com.sopt.geonppang.util.ItemDiffCallback
 
 class BestReviewAdapter(
@@ -28,6 +29,7 @@ class BestReviewAdapter(
             binding.executePendingBindings()
 
             binding.root.setOnClickListener {
+                AmplitudeUtils.trackEvent(CLICK_RECOMMEND_REVIEW)
                 moveToDetail(MAIN, review.bakeryId)
             }
         }
@@ -45,5 +47,6 @@ class BestReviewAdapter(
 
     companion object {
         const val MAIN = "mainActivity"
+        const val CLICK_RECOMMEND_REVIEW = "click_recommend_review"
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/home/HomeFragment.kt
@@ -90,7 +90,9 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     }
 
     private fun moveToSearch() {
-        startActivity(Intent(requireContext(), SearchActivity::class.java))
+        val intent = Intent(requireContext(), SearchActivity::class.java)
+        intent.putExtra(VIEW_TO_VIEW, HOME_TO_SEARCH)
+        startActivity(intent)
     }
 
     private fun moveToDetail(activityName: String, bakeryId: Int) {
@@ -111,6 +113,8 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         const val BAKERY_ID = "bakeryId"
         const val ACTIVITY_NAME = "activityName"
         const val FILTER_INFO = "filterInfo"
+        const val VIEW_TO_VIEW = "viewToView"
+        const val HOME_TO_SEARCH = "homeToSearch"
         const val CLICK_SEARCH_HOME = "click_search_home"
         const val START_FILTER_HOME = "start_filter_home"
     }

--- a/app/src/main/java/com/sopt/geonppang/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/home/HomeFragment.kt
@@ -12,6 +12,7 @@ import com.sopt.geonppang.presentation.detail.DetailActivity
 import com.sopt.geonppang.presentation.filterSetting.FilterSettingActivity
 import com.sopt.geonppang.presentation.search.SearchActivity
 import com.sopt.geonppang.presentation.type.FilterInfoType
+import com.sopt.geonppang.util.AmplitudeUtils
 import com.sopt.geonppang.util.UiState
 import com.sopt.geonppang.util.binding.BindingFragment
 import com.sopt.geonppang.util.setVisibility
@@ -46,10 +47,12 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
 
     private fun addListeners() {
         binding.tvHomeSearch.setOnClickListener {
+            AmplitudeUtils.trackEvent(CLICK_SEARCH_HOME)
             moveToSearch()
         }
 
         binding.ivHomeFilter.setOnClickListener {
+            AmplitudeUtils.trackEvent(START_FILTER_HOME)
             moveToFilter()
         }
 
@@ -108,5 +111,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         const val BAKERY_ID = "bakeryId"
         const val ACTIVITY_NAME = "activityName"
         const val FILTER_INFO = "filterInfo"
+        const val CLICK_SEARCH_HOME = "click_search_home"
+        const val START_FILTER_HOME = "start_filter_home"
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/search/SearchActivity.kt
@@ -12,6 +12,7 @@ import com.sopt.geonppang.R
 import com.sopt.geonppang.databinding.ActivitySearchBinding
 import com.sopt.geonppang.presentation.common.BakeryAdapter
 import com.sopt.geonppang.presentation.detail.DetailActivity
+import com.sopt.geonppang.util.AmplitudeUtils
 import com.sopt.geonppang.util.UiState
 import com.sopt.geonppang.util.binding.BindingActivity
 import com.sopt.geonppang.util.extension.hideKeyboard
@@ -53,6 +54,7 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
 
         binding.etSearch.setOnKeyListener { _, keyCode, event ->
             if ((event.action == KeyEvent.ACTION_DOWN) && (keyCode == KeyEvent.KEYCODE_ENTER)) {
+                completeFilteringInParticularView()
                 viewModel.searchBakeryList()
                 hideKeyboard(binding.root)
                 true
@@ -82,6 +84,27 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
         startActivity(intent)
     }
 
+    private fun completeFilteringInParticularView() {
+        val viewToView = intent.getStringExtra(VIEW_TO_VIEW)
+        when (viewToView) {
+            HOME_TO_SEARCH -> {
+                AmplitudeUtils.trackEventWithProperties(
+                    COMPLETE_SEARCH_HOME,
+                    KEYWORD,
+                    viewModel.inputSearch.value
+                )
+            }
+
+            BAKERY_LIST_TO_SEARCH -> {
+                AmplitudeUtils.trackEventWithProperties(
+                    COMPLETE_SEARCH_LIST,
+                    KEYWORD,
+                    viewModel.inputSearch.value
+                )
+            }
+        }
+    }
+
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
         hideKeyboard(binding.root)
         return super.dispatchTouchEvent(ev)
@@ -89,5 +112,11 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
 
     companion object {
         const val BAKERY_ID = "bakeryId"
+        const val VIEW_TO_VIEW = "viewToView"
+        const val HOME_TO_SEARCH = "homeToSearch"
+        const val BAKERY_LIST_TO_SEARCH = "bakeryListToSearch"
+        const val COMPLETE_SEARCH_HOME = "complete_search_home"
+        const val COMPLETE_SEARCH_LIST = "complete_search_list"
+        const val KEYWORD = "keyword"
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #133

## Work Description ✏️
- 홈 뷰에서 베스트 건빵집 베스트 리뷰 칩 선택하는지에 대한 이벤트 코드 심기
- 홈 뷰에서 검색뷰, 필터뷰로 이동하는 비율 트레킹하는 이벤트 코드 심기
- 특정뷰에서 -> 필터뷰로 이동했을때의, 필터뷰 이탈률 및 필터 완료율 코드 심기
- 특정뷰 -> 검색뷰로 이동했을 때의 검색 완료 비율 및 검색어에 대한이벤트 코드 심기

## Screenshot 📸
<img src="https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/77060011/1f608a39-6e58-4ba8-9f29-d7f2e22999cc"/>

<img src="https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/77060011/e3022864-e09d-4767-925b-1270ae1c6084"/>


## To Reviewers 📢
