### PR TITLE
[feat] 자체 회원가입 api 연동 및 회원가입 로직 구현

### DIFF
--- a/app/src/main/java/com/sopt/geonppang/data/datasource/local/GPDataSource.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/datasource/local/GPDataSource.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class GPDataStore @Inject constructor(@ApplicationContext context: Context) {
+class GPDataSource @Inject constructor(@ApplicationContext context: Context) {
     private val masterKey = MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
         .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
         .build()
@@ -57,10 +57,6 @@ class GPDataStore @Inject constructor(@ApplicationContext context: Context) {
             clear()
         }
     }
-
-    var userNickname: String
-        set(value) = dataStore.edit { putString(NICKNAME, value) }
-        get() = dataStore.getString(NICKNAME, "") ?: ""
 
     companion object {
         const val FILE_NAME = "Gpdatastore"

--- a/app/src/main/java/com/sopt/geonppang/data/datasource/remote/AuthDataSource.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/datasource/remote/AuthDataSource.kt
@@ -1,7 +1,9 @@
 package com.sopt.geonppang.data.datasource.remote
 
+import com.sopt.geonppang.data.model.request.RequestNicknameSetting
 import com.sopt.geonppang.data.model.request.RequestSignup
 import com.sopt.geonppang.data.model.response.ResponseLogout
+import com.sopt.geonppang.data.model.response.ResponseNickNameSetting
 import com.sopt.geonppang.data.model.response.ResponseSignup
 import com.sopt.geonppang.data.model.response.ResponseWithdraw
 import com.sopt.geonppang.data.service.AuthService
@@ -11,9 +13,14 @@ import javax.inject.Inject
 class AuthDataSource @Inject constructor(
     private val authService: AuthService,
 ) {
-    suspend fun postSignup(platformToken: String, requestSignup: RequestSignup): Response<ResponseSignup> =
+    suspend fun postSignup(
+        platformToken: String,
+        requestSignup: RequestSignup
+    ): Response<ResponseSignup> =
         authService.postSignup(platformToken, requestSignup)
 
     suspend fun withdraw(): ResponseWithdraw = authService.withdraw()
     suspend fun logout(): ResponseLogout = authService.logout()
+    suspend fun settingNickname(nickname: RequestNicknameSetting): ResponseNickNameSetting =
+        authService.settingNickName(nickname)
 }

--- a/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
@@ -1,18 +1,18 @@
 package com.sopt.geonppang.data.interceptor
 
-import com.sopt.geonppang.data.datasource.local.GPDataStore
+import com.sopt.geonppang.data.datasource.local.GPDataSource
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
-    private val gpDataStore: GPDataStore
+    private val gpDataSource: GPDataSource
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
         val authRequest =
-            originalRequest.newBuilder().addHeader("Authorization", gpDataStore.accessToken)
+            originalRequest.newBuilder().addHeader("Authorization", gpDataSource.accessToken)
                 .build()
         val response = chain.proceed(authRequest)
 

--- a/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
@@ -1,16 +1,18 @@
 package com.sopt.geonppang.data.interceptor
 
-import com.sopt.geonppang.BuildConfig
+import com.sopt.geonppang.data.datasource.local.GPDataStore
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
-class AuthInterceptor @Inject constructor() : Interceptor {
+class AuthInterceptor @Inject constructor(
+    private val gpDataStore: GPDataStore
+) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
         val authRequest =
-            originalRequest.newBuilder().addHeader("Authorization", BuildConfig.ACCESS_TOKEN)
+            originalRequest.newBuilder().addHeader("Authorization", gpDataStore.accessToken)
                 .build()
         val response = chain.proceed(authRequest)
 

--- a/app/src/main/java/com/sopt/geonppang/data/model/request/RequestNicknameSetting.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/model/request/RequestNicknameSetting.kt
@@ -1,0 +1,8 @@
+package com.sopt.geonppang.data.model.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestNicknameSetting(
+    val nickname: String
+)

--- a/app/src/main/java/com/sopt/geonppang/data/model/response/ResponseNickNameSetting.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/model/response/ResponseNickNameSetting.kt
@@ -1,0 +1,17 @@
+package com.sopt.geonppang.data.model.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseNickNameSetting(
+    val code: Int,
+    val data: Data?,
+    val message: String
+) {
+    @Serializable
+    data class Data(
+        val memberId: Int,
+        val nickname: String,
+        val role: String
+    )
+}

--- a/app/src/main/java/com/sopt/geonppang/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/repository/AuthRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.sopt.geonppang.data.repository
 
 import com.sopt.geonppang.data.datasource.remote.AuthDataSource
+import com.sopt.geonppang.data.model.request.RequestNicknameSetting
 import com.sopt.geonppang.data.model.request.RequestSignup
 import com.sopt.geonppang.data.model.response.ResponseLogout
+import com.sopt.geonppang.data.model.response.ResponseNickNameSetting
 import com.sopt.geonppang.data.model.response.ResponseSignup
 import com.sopt.geonppang.data.model.response.ResponseWithdraw
 import com.sopt.geonppang.domain.repository.AuthRepository
@@ -23,4 +25,7 @@ class AuthRepositoryImpl @Inject constructor(
 
     override suspend fun logout(): Result<ResponseLogout> =
         runCatching { authDataSource.logout() }
+
+    override suspend fun settingNickname(nickName: RequestNicknameSetting): Result<ResponseNickNameSetting> =
+        runCatching { authDataSource.settingNickname(nickName) }
 }

--- a/app/src/main/java/com/sopt/geonppang/data/service/AuthService.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/service/AuthService.kt
@@ -1,7 +1,9 @@
 package com.sopt.geonppang.data.service
 
+import com.sopt.geonppang.data.model.request.RequestNicknameSetting
 import com.sopt.geonppang.data.model.request.RequestSignup
 import com.sopt.geonppang.data.model.response.ResponseLogout
+import com.sopt.geonppang.data.model.response.ResponseNickNameSetting
 import com.sopt.geonppang.data.model.response.ResponseSignup
 import com.sopt.geonppang.data.model.response.ResponseWithdraw
 import retrofit2.Response
@@ -22,4 +24,9 @@ interface AuthService {
 
     @POST("auth/logout")
     suspend fun logout(): ResponseLogout
+
+    @POST("member/nickname")
+    suspend fun settingNickName(
+        @Body requestNicknameSetting: RequestNicknameSetting
+    ): ResponseNickNameSetting
 }

--- a/app/src/main/java/com/sopt/geonppang/data/service/KakaoAuthService.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/service/KakaoAuthService.kt
@@ -18,7 +18,7 @@ class KakaoAuthService @Inject constructor(
         else KAKAO_ACCOUNT
 
     fun startKakaoLogin(
-        loginListener: (PlatformType, String) -> Unit
+        loginListener: (platformType: PlatformType, platformToken: String, email: String, password: String, nickname: String) -> Unit
     ) {
         val kakaoLoginCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
             if (error != null) {
@@ -46,9 +46,9 @@ class KakaoAuthService @Inject constructor(
 
     private fun handleLoginSuccess(
         oAuthToken: OAuthToken,
-        loginListener: (PlatformType, String) -> Unit
+        loginListener: (platformType: PlatformType, platformToken: String, email: String, password: String, nickname: String) -> Unit
     ) {
-        loginListener(PlatformType.KAKAO, oAuthToken.accessToken)
+        loginListener(PlatformType.KAKAO, oAuthToken.accessToken, "", "", "")
     }
 
     private fun handleLoginError(throwable: Throwable) {

--- a/app/src/main/java/com/sopt/geonppang/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/sopt/geonppang/domain/repository/AuthRepository.kt
@@ -1,13 +1,20 @@
 package com.sopt.geonppang.domain.repository
 
+import com.sopt.geonppang.data.model.request.RequestNicknameSetting
 import com.sopt.geonppang.data.model.request.RequestSignup
 import com.sopt.geonppang.data.model.response.ResponseLogout
+import com.sopt.geonppang.data.model.response.ResponseNickNameSetting
 import com.sopt.geonppang.data.model.response.ResponseSignup
 import com.sopt.geonppang.data.model.response.ResponseWithdraw
 import retrofit2.Response
 
 interface AuthRepository {
-    suspend fun signup(platformToken: String, requestSignup: RequestSignup): Result<Response<ResponseSignup>>
+    suspend fun signup(
+        platformToken: String,
+        requestSignup: RequestSignup
+    ): Result<Response<ResponseSignup>>
+
     suspend fun withdraw(): Result<ResponseWithdraw>
     suspend fun logout(): Result<ResponseLogout>
+    suspend fun settingNickname(nickName: RequestNicknameSetting): Result<ResponseNickNameSetting>
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/AuthViewModel.kt
@@ -1,13 +1,12 @@
 package com.sopt.geonppang.presentation.auth
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
-import com.sopt.geonppang.data.datasource.local.GPDataStore
+import com.sopt.geonppang.data.datasource.local.GPDataSource
 import com.sopt.geonppang.data.model.request.RequestNicknameSetting
 import com.sopt.geonppang.data.model.request.RequestSignup
 import com.sopt.geonppang.domain.repository.AuthRepository
@@ -23,7 +22,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
-    private val gpDataStore: GPDataStore,
+    private val gpDataSource: GPDataSource,
     private val authRepository: AuthRepository
 ) : ViewModel() {
     val email = MutableLiveData("")
@@ -94,7 +93,7 @@ class AuthViewModel @Inject constructor(
         password: String,
         nickName: String
     ) {
-        gpDataStore.platformType = platformType.name
+        gpDataSource.platformType = platformType.name
         viewModelScope.launch {
             authRepository.signup(
                 platformToken = platformToken,
@@ -112,13 +111,13 @@ class AuthViewModel @Inject constructor(
                     val refreshToken = responseHeader[AUTHORIZATION_REFRESH].toString()
                     _authRoleType.value =
                         if (responseBody?.role == AuthRoleType.GUEST.name) AuthRoleType.GUEST else AuthRoleType.USER
-                    gpDataStore.accessToken = BEARER_PREFIX + accessToken
+                    gpDataSource.accessToken = BEARER_PREFIX + accessToken
                     if (_authRoleType.value == AuthRoleType.USER) {
-                        gpDataStore.refreshToken = BEARER_PREFIX + refreshToken
+                        gpDataSource.refreshToken = BEARER_PREFIX + refreshToken
                     }
                     _signUpState.value = UiState.Success(true)
-                    Timber.tag("access token").d(gpDataStore.accessToken)
-                    Timber.tag("refresh token").d(gpDataStore.refreshToken)
+                    Timber.tag("access token").d(gpDataSource.accessToken)
+                    Timber.tag("refresh token").d(gpDataSource.refreshToken)
                 }
                 .onFailure { throwable ->
                     Timber.e(throwable.message)

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/AuthViewModel.kt
@@ -87,17 +87,22 @@ class AuthViewModel @Inject constructor(
         return isValidNickname.value == true
     }
 
-    // 현재 소셜 회원가입만 고려해 email, password, nickname을 임의로 ""로 해놓았습니다.
-    fun singUp(platformType: PlatformType, platformToken: String) {
+    fun signUp(
+        platformType: PlatformType,
+        platformToken: String,
+        email: String,
+        password: String,
+        nickName: String
+    ) {
         gpDataStore.platformType = platformType.name
         viewModelScope.launch {
             authRepository.signup(
                 platformToken = platformToken,
                 RequestSignup(
                     platformType.name,
-                    "",
-                    "",
-                    ""
+                    email,
+                    password,
+                    nickName
                 )
             )
                 .onSuccess { signUpResponse ->
@@ -111,8 +116,9 @@ class AuthViewModel @Inject constructor(
                     if (_authRoleType.value == AuthRoleType.USER) {
                         gpDataStore.refreshToken = BEARER_PREFIX + refreshToken
                     }
-                    Log.d("header", gpDataStore.accessToken)
-                    Log.d("header2", gpDataStore.refreshToken)
+                    _signUpState.value = UiState.Success(true)
+                    Timber.tag("access token").d(gpDataStore.accessToken)
+                    Timber.tag("refresh token").d(gpDataStore.refreshToken)
                 }
                 .onFailure { throwable ->
                     Timber.e(throwable.message)

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/AuthViewModel.kt
@@ -8,10 +8,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.sopt.geonppang.data.datasource.local.GPDataStore
+import com.sopt.geonppang.data.model.request.RequestNicknameSetting
 import com.sopt.geonppang.data.model.request.RequestSignup
 import com.sopt.geonppang.domain.repository.AuthRepository
 import com.sopt.geonppang.presentation.type.AuthRoleType
 import com.sopt.geonppang.presentation.type.PlatformType
+import com.sopt.geonppang.util.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -70,6 +72,9 @@ class AuthViewModel @Inject constructor(
         addSource(nickname) { value = checkNicknameCondition() }
     }
 
+    private val _signUpState = MutableStateFlow<UiState<Boolean>>(UiState.Loading)
+    val signUpState get() = _signUpState.asStateFlow()
+
     private fun isPasswordDoubleCheck(): Boolean {
         return password.value.toString() == password_check.value.toString() && !password.value.isNullOrBlank() && !password_check.value.isNullOrBlank()
     }
@@ -112,6 +117,20 @@ class AuthViewModel @Inject constructor(
                 .onFailure { throwable ->
                     Timber.e(throwable.message)
                 }
+        }
+    }
+
+    fun settingNickName() {
+        viewModelScope.launch {
+            nickname.value?.let { nickname ->
+                authRepository.settingNickname(RequestNicknameSetting(nickname))
+                    .onSuccess {
+                        _signUpState.value = UiState.Success(true)
+                    }
+                    .onFailure { throwable ->
+                        Timber.e(throwable.message)
+                    }
+            }
         }
     }
 

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/SignActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/SignActivity.kt
@@ -3,12 +3,18 @@ package com.sopt.geonppang.presentation.auth
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.sopt.geonppang.R
 import com.sopt.geonppang.data.service.KakaoAuthService
 import com.sopt.geonppang.databinding.ActivitySignBinding
+import com.sopt.geonppang.presentation.MainActivity
 import com.sopt.geonppang.presentation.login.LoginActivity
+import com.sopt.geonppang.presentation.type.AuthRoleType
 import com.sopt.geonppang.util.binding.BindingActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -20,6 +26,7 @@ class SignActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         addListeners()
+        collectData()
     }
 
     private fun addListeners() {
@@ -27,12 +34,27 @@ class SignActivity :
             kakaoAuthService.startKakaoLogin(authViewModel::singUp)
         }
         binding.tvLoginWithEmail.setOnClickListener {
-            kakaoAuthService.disconnectKakao()
             moveToLogin()
         }
         binding.tvSignupWithEmail.setOnClickListener {
             moveToSignUp()
         }
+    }
+
+    private fun collectData() {
+        authViewModel.authRoleType.flowWithLifecycle(lifecycle).onEach { role ->
+            when (role) {
+                AuthRoleType.GUEST -> {
+                    moveToNickNameSetting()
+                }
+
+                AuthRoleType.USER -> {
+                    moveToMain()
+                }
+
+                else -> {}
+            }
+        }.launchIn(lifecycleScope)
     }
 
     private fun moveToSignUp() {
@@ -41,5 +63,13 @@ class SignActivity :
 
     private fun moveToLogin() {
         startActivity(Intent(this, LoginActivity::class.java))
+    }
+
+    private fun moveToNickNameSetting() {
+        startActivity(Intent(this, SignUpNicknameActivity::class.java))
+    }
+
+    private fun moveToMain() {
+        startActivity(Intent(this, MainActivity::class.java))
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/SignActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/SignActivity.kt
@@ -6,11 +6,13 @@ import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.sopt.geonppang.R
+import com.sopt.geonppang.data.datasource.local.GPDataStore
 import com.sopt.geonppang.data.service.KakaoAuthService
 import com.sopt.geonppang.databinding.ActivitySignBinding
 import com.sopt.geonppang.presentation.MainActivity
 import com.sopt.geonppang.presentation.login.LoginActivity
 import com.sopt.geonppang.presentation.type.AuthRoleType
+import com.sopt.geonppang.presentation.type.PlatformType
 import com.sopt.geonppang.util.binding.BindingActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
@@ -31,7 +33,7 @@ class SignActivity :
 
     private fun addListeners() {
         binding.btnStartWithKakao.setOnClickListener {
-            kakaoAuthService.startKakaoLogin(authViewModel::singUp)
+            kakaoAuthService.startKakaoLogin(authViewModel::signUp)
         }
         binding.tvLoginWithEmail.setOnClickListener {
             moveToLogin()
@@ -58,6 +60,8 @@ class SignActivity :
     }
 
     private fun moveToSignUp() {
+        val gpDataStore = GPDataStore(this)
+        gpDataStore.platformType = PlatformType.NONE.name
         startActivity(Intent(this, SignUpActivity::class.java))
     }
 

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/SignActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/SignActivity.kt
@@ -32,7 +32,7 @@ class SignActivity :
     }
 
     private fun addListeners() {
-        binding.btnStartWithKakao.setOnClickListener {
+        binding.btnStartKakao.setOnClickListener {
             kakaoAuthService.startKakaoLogin(authViewModel::signUp)
         }
         binding.tvLoginWithEmail.setOnClickListener {

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/SignActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/SignActivity.kt
@@ -6,7 +6,7 @@ import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.sopt.geonppang.R
-import com.sopt.geonppang.data.datasource.local.GPDataStore
+import com.sopt.geonppang.data.datasource.local.GPDataSource
 import com.sopt.geonppang.data.service.KakaoAuthService
 import com.sopt.geonppang.databinding.ActivitySignBinding
 import com.sopt.geonppang.presentation.MainActivity
@@ -60,8 +60,8 @@ class SignActivity :
     }
 
     private fun moveToSignUp() {
-        val gpDataStore = GPDataStore(this)
-        gpDataStore.platformType = PlatformType.NONE.name
+        val gpDataSource = GPDataSource(this)
+        gpDataSource.platformType = PlatformType.NONE.name
         startActivity(Intent(this, SignUpActivity::class.java))
     }
 

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/SignUpActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/SignUpActivity.kt
@@ -41,6 +41,14 @@ class SignUpActivity :
     }
 
     private fun moveToNickname() {
-        startActivity(Intent(this, SignUpNicknameActivity::class.java))
+        val intent = Intent(this, SignUpNicknameActivity::class.java)
+        intent.putExtra(EMAIL, viewModel.email.value)
+        intent.putExtra(PASSWORD, viewModel.password.value)
+        startActivity(intent)
+    }
+
+    companion object {
+        const val EMAIL = "email"
+        const val PASSWORD = "password"
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/SignUpNicknameActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/SignUpNicknameActivity.kt
@@ -6,7 +6,7 @@ import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.sopt.geonppang.R
-import com.sopt.geonppang.data.datasource.local.GPDataStore
+import com.sopt.geonppang.data.datasource.local.GPDataSource
 import com.sopt.geonppang.databinding.ActivitySignupNicknameBinding
 import com.sopt.geonppang.presentation.type.PlatformType
 import com.sopt.geonppang.util.UiState
@@ -62,8 +62,8 @@ class SignUpNicknameActivity :
     }
 
     private fun completeSignUp() {
-        val gpDataStore = GPDataStore(this)
-        when (gpDataStore.platformType) {
+        val gpDataSource = GPDataSource(this)
+        when (gpDataSource.platformType) {
             PlatformType.KAKAO.name -> {
                 viewModel.settingNickName()
             }

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/SignUpNicknameActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/SignUpNicknameActivity.kt
@@ -6,7 +6,9 @@ import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.sopt.geonppang.R
+import com.sopt.geonppang.data.datasource.local.GPDataStore
 import com.sopt.geonppang.databinding.ActivitySignupNicknameBinding
+import com.sopt.geonppang.presentation.type.PlatformType
 import com.sopt.geonppang.util.UiState
 import com.sopt.geonppang.util.binding.BindingActivity
 import com.sopt.geonppang.util.extension.hideKeyboard
@@ -43,7 +45,7 @@ class SignUpNicknameActivity :
         }
 
         binding.btnNext.setOnClickListener {
-            viewModel.settingNickName()
+            completeSignUp()
         }
     }
 
@@ -59,6 +61,27 @@ class SignUpNicknameActivity :
         }.launchIn(lifecycleScope)
     }
 
+    private fun completeSignUp() {
+        val gpDataStore = GPDataStore(this)
+        when (gpDataStore.platformType) {
+            PlatformType.KAKAO.name -> {
+                viewModel.settingNickName()
+            }
+
+            PlatformType.NONE.name -> {
+                val email = intent.getStringExtra(EMAIL)
+                val password = intent.getStringExtra(PASSWORD)
+                viewModel.signUp(
+                    PlatformType.NONE,
+                    "",
+                    email ?: "",
+                    password ?: "",
+                    viewModel.nickname.value ?: ""
+                )
+            }
+        }
+    }
+
     private fun moveToWelcome() {
         val intent = Intent(this, WelcomeActivity::class.java)
         intent.putExtra(NICKNAME, viewModel.nickname.value)
@@ -67,5 +90,7 @@ class SignUpNicknameActivity :
 
     companion object {
         const val NICKNAME = "nickName"
+        const val EMAIL = "email"
+        const val PASSWORD = "password"
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/SignUpNicknameActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/SignUpNicknameActivity.kt
@@ -3,11 +3,16 @@ package com.sopt.geonppang.presentation.auth
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.sopt.geonppang.R
 import com.sopt.geonppang.databinding.ActivitySignupNicknameBinding
+import com.sopt.geonppang.util.UiState
 import com.sopt.geonppang.util.binding.BindingActivity
 import com.sopt.geonppang.util.extension.hideKeyboard
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class SignUpNicknameActivity :
@@ -20,6 +25,7 @@ class SignUpNicknameActivity :
         binding.lifecycleOwner = this
 
         addListeners()
+        collectData()
     }
 
     private fun addListeners() {
@@ -37,10 +43,26 @@ class SignUpNicknameActivity :
         }
 
         binding.btnNext.setOnClickListener {
-            val intent = Intent(this, WelcomeActivity::class.java)
-            intent.putExtra(NICKNAME, viewModel.nickname.value)
-            startActivity(intent)
+            viewModel.settingNickName()
         }
+    }
+
+    private fun collectData() {
+        viewModel.signUpState.flowWithLifecycle(lifecycle).onEach {
+            when (it) {
+                is UiState.Success -> {
+                    moveToWelcome()
+                }
+
+                else -> {}
+            }
+        }.launchIn(lifecycleScope)
+    }
+
+    private fun moveToWelcome() {
+        val intent = Intent(this, WelcomeActivity::class.java)
+        intent.putExtra(NICKNAME, viewModel.nickname.value)
+        startActivity(intent)
     }
 
     companion object {

--- a/app/src/main/res/drawable/shape_sign_kakao_btn.xml
+++ b/app/src/main/res/drawable/shape_sign_kakao_btn.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/kakao_point" />
-    <corners android:radius="@dimen/spacing12" />
-</shape>

--- a/app/src/main/res/layout/activity_sign.xml
+++ b/app/src/main/res/layout/activity_sign.xml
@@ -13,8 +13,7 @@
             android:id="@+id/iv_logo"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="121dp"
-            android:layout_marginTop="205dp"
+            android:layout_marginTop="177dp"
             android:src="@drawable/img_gunbbang_splash"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -22,54 +21,49 @@
 
         <ImageView
             android:id="@+id/iv_logo_text"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="166dp"
             android:layout_marginTop="14dp"
-            android:adjustViewBounds="true"
             android:padding="4dp"
             android:src="@drawable/img_logo_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/iv_logo" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_kakao"
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_start_kakao"
+            style="@style/Widget.FullButton.Basic"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="24dp"
             android:layout_marginTop="56dp"
-            android:background="@drawable/shape_sign_kakao_btn"
+            android:backgroundTint="@color/kakao_point"
+            android:paddingVertical="18dp"
+            android:text="@string/btn_kakao_sign"
+            android:textAlignment="center"
+            android:textAppearance="@style/TextAppearance.Headline"
+            android:textColor="@color/black"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/iv_logo_text">
+            app:layout_constraintTop_toBottomOf="@id/iv_logo_text" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_start_with_kakao"
-                style="@style/Widget.FullButton.Basic"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="10dp"
-                android:backgroundTint="@color/kakao_point"
-                android:drawableLeft="@drawable/ic_kakao"
-                android:paddingVertical="18dp"
-                android:text="@string/btn_kakao_sign"
-                android:textAlignment="center"
-                android:textAppearance="@style/TextAppearance.Headline"
-                android:textColor="@color/black"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="26dp"
+            android:src="@drawable/ic_kakao"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_start_kakao"
+            app:layout_constraintStart_toStartOf="@+id/btn_start_kakao"
+            app:layout_constraintTop_toTopOf="@+id/btn_start_kakao" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_start_with_email"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            app:layout_constraintEnd_toEndOf="@id/layout_kakao"
-            app:layout_constraintStart_toStartOf="@id/layout_kakao"
-            app:layout_constraintTop_toBottomOf="@id/layout_kakao">
+            app:layout_constraintEnd_toEndOf="@id/btn_start_kakao"
+            app:layout_constraintStart_toStartOf="@id/btn_start_kakao"
+            app:layout_constraintTop_toBottomOf="@id/btn_start_kakao">
 
             <TextView
                 android:id="@+id/tv_login_with_email"


### PR DESCRIPTION
## Related issue 🛠
- closed #153 

## Work Description ✏️
- 자체 회원가입 api 연동
- 소셜로그인시, 소셜로그인 성공(GUEST) 후 닉네임 설정 api 연동(-> USER)
- 회원가입 분기처리

## Screenshot 📸

https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/77060011/a81f8d01-a0c0-42f2-870c-7eb1047a3a4c

https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/77060011/0893395a-fe4e-4a25-9ffa-9b09113f64ff

https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/77060011/69d61c21-1fff-4f03-8d3a-2cf7d569f83f




## Uncompleted Tasks 😅
- [x] 로그인 시작뷰 디자인 수정
- [ ] 자동로그인 구현

## To Reviewers 📢
