### PR TITLE
[feat]  토큰 재발급 로직 구현(토큰 재발급 실패시 SignActivity 이동

### DIFF
--- a/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
@@ -1,12 +1,20 @@
 package com.sopt.geonppang.data.interceptor
 
+import android.app.Application
+import android.content.Intent
+import com.sopt.geonppang.BuildConfig
 import com.sopt.geonppang.data.datasource.local.GPDataSource
+import com.sopt.geonppang.presentation.auth.SignActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
-    private val gpDataSource: GPDataSource
+    private val gpDataSource: GPDataSource,
+    private val context: Application,
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
@@ -18,9 +26,49 @@ class AuthInterceptor @Inject constructor(
 
         when (response.code) {
             401 -> {
-                // TODO 토큰 재발급 api 연동
+                response.close()
+                val refreshTokenRequest = originalRequest.newBuilder().get()
+                    .url("${BuildConfig.GP_BASE_URL}auth/refresh")
+                    .addHeader(ACCESS_TOKEN, gpDataSource.accessToken)
+                    .addHeader(REFRESH_TOKEN, gpDataSource.refreshToken)
+                    .build()
+                val refreshTokenResponse = chain.proceed(refreshTokenRequest)
+
+                if (refreshTokenResponse.isSuccessful) {
+                    val responseHeader = refreshTokenResponse.headers
+                    val responseAccessToken = responseHeader[ACCESS_TOKEN]
+                    val responseRefreshToken = responseHeader[REFRESH_TOKEN]
+
+                    with(gpDataSource) {
+                        accessToken = BEARER_PREFIX + responseAccessToken.toString()
+                        refreshToken = BEARER_PREFIX + responseRefreshToken.toString()
+                    }
+
+                    refreshTokenResponse.close()
+                    val newRequest = originalRequest.newBuilder()
+                        .addHeader(ACCESS_TOKEN, gpDataSource.accessToken)
+                        .addHeader(REFRESH_TOKEN, gpDataSource.refreshToken)
+                        .build()
+                    return chain.proceed(newRequest)
+                } else {
+                    with(context) {
+                        CoroutineScope(Dispatchers.Main).launch {
+                            startActivity(
+                                Intent(this@with, SignActivity::class.java)
+                                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+                            )
+                        }
+                    }
+                    gpDataSource.clear()
+                }
             }
         }
         return response
+    }
+
+    companion object {
+        const val ACCESS_TOKEN = "Authorization"
+        const val REFRESH_TOKEN = "Authorization-refresh"
+        const val BEARER_PREFIX = "Bearer "
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #156 

## Work Description ✏️
- 토큰 재발급 api 연동 (401 status code 떴을 때)
- 재발급시 response header값 받아와서 local storage에 저장
- 토큰 재발급 확인
- 토큰 재발급 실패시 로그인 페이지로 이동

## Screenshot 📸
토큰 재발급 확인(엑세스 토큰 만료 후 재발급 되는 거 확인했습니다!)
![image](https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/77060011/72942da8-6dfc-4441-9972-b6476e8c2922)
![image](https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/77060011/2f7f1627-31e6-40e5-8a66-6198a74ed332)


## To Reviewers 📢
이거 머지하면 이제 local property에서 ACCESS TOKEN 지우고 진짜 회원가입 하고 쓰시면 됩니다!(현재 자체 로그인이 안되어 있어서, 소셜로 로그인 하세염!)