### PR TITLE
[fix] 인터셉터에서 재발급 실패시 startActivity를 호출할때 발생하는 ANR 오류 해결

### DIFF
--- a/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
@@ -55,7 +55,7 @@ class AuthInterceptor @Inject constructor(
                         CoroutineScope(Dispatchers.Main).launch {
                             startActivity(
                                 Intent(this@with, SignActivity::class.java)
-                                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                             )
                         }
                     }


### PR DESCRIPTION
## Related issue 🛠
- closed #167 

## Work Description ✏️
- 인터셉터에서 재발급 실패시 startActivity를 호출할때 발생하는 ANR 오류 해결

## To Reviewers 📢
 파이어베이스테 관련 ANR 오류가 수집되서, 문제를 해결했습니다. 단순히 clear Top 때문이었는지는 모르겠지만,, 찾아보니 ~new_task를 쓰라고 해서 이거만 남겼습니다.