### PR TITLE
[feat] 카카오 회원가입 시 응답 헤더값 자체 디비에 저장

### DIFF
--- a/app/src/main/java/com/sopt/geonppang/data/datasource/remote/AuthDataSource.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/datasource/remote/AuthDataSource.kt
@@ -23,7 +23,7 @@ class AuthDataSource @Inject constructor(
 
     suspend fun withdraw(): ResponseWithdraw = authService.withdraw()
     suspend fun logout(): ResponseLogout = authService.logout()
-    suspend fun settingNickname(nickname: RequestNicknameSetting): ResponseNickNameSetting =
+    suspend fun settingNickname(nickname: RequestNicknameSetting): Response<ResponseNickNameSetting> =
         authService.settingNickName(nickname)
     suspend fun login(requestLogin: RequestLogin): Response<ResponseLogin> = authService.login(requestLogin)
 }

--- a/app/src/main/java/com/sopt/geonppang/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/repository/AuthRepositoryImpl.kt
@@ -28,7 +28,7 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun logout(): Result<ResponseLogout> =
         runCatching { authDataSource.logout() }
 
-    override suspend fun settingNickname(nickName: RequestNicknameSetting): Result<ResponseNickNameSetting> =
+    override suspend fun settingNickname(nickName: RequestNicknameSetting): Result<Response<ResponseNickNameSetting>> =
         runCatching { authDataSource.settingNickname(nickName) }
 
     override suspend fun login(responseLogin: RequestLogin): Result<Response<ResponseLogin>> =

--- a/app/src/main/java/com/sopt/geonppang/data/service/AuthService.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/service/AuthService.kt
@@ -35,5 +35,5 @@ interface AuthService {
     @POST("member/nickname")
     suspend fun settingNickName(
         @Body requestNicknameSetting: RequestNicknameSetting
-    ): ResponseNickNameSetting
+    ): Response<ResponseNickNameSetting>
 }

--- a/app/src/main/java/com/sopt/geonppang/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/sopt/geonppang/domain/repository/AuthRepository.kt
@@ -18,6 +18,6 @@ interface AuthRepository {
 
     suspend fun withdraw(): Result<ResponseWithdraw>
     suspend fun logout(): Result<ResponseLogout>
-    suspend fun settingNickname(nickName: RequestNicknameSetting): Result<ResponseNickNameSetting>
+    suspend fun settingNickname(nickName: RequestNicknameSetting): Result<Response<ResponseNickNameSetting>>
     suspend fun login(requestLogin: RequestLogin): Result<Response<ResponseLogin>>
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/auth/AuthViewModel.kt
@@ -129,7 +129,13 @@ class AuthViewModel @Inject constructor(
         viewModelScope.launch {
             nickname.value?.let { nickname ->
                 authRepository.settingNickname(RequestNicknameSetting(nickname))
-                    .onSuccess {
+                    .onSuccess { response ->
+                        val responseHeader = response.headers()
+                        val accessToken = responseHeader[AUTHORIZATION].toString()
+                        val refreshToken = responseHeader[AUTHORIZATION_REFRESH].toString()
+                        gpDataSource.accessToken = BEARER_PREFIX + accessToken
+                        gpDataSource.refreshToken = BEARER_PREFIX + refreshToken
+
                         _signUpState.value = UiState.Success(true)
                     }
                     .onFailure { throwable ->

--- a/app/src/main/java/com/sopt/geonppang/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/home/HomeFragment.kt
@@ -2,11 +2,13 @@ package com.sopt.geonppang.presentation.home
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.sopt.geonppang.R
+import com.sopt.geonppang.data.datasource.local.GPDataSource
 import com.sopt.geonppang.databinding.FragmentHomeBinding
 import com.sopt.geonppang.presentation.detail.DetailActivity
 import com.sopt.geonppang.presentation.detail.DetailActivity.Companion.SOURCE
@@ -37,6 +39,9 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         initLayout()
         addListeners()
         collectData()
+
+        Log.d("access token", GPDataSource(requireActivity()).accessToken)
+        Log.d("refresh token", GPDataSource(requireActivity()).refreshToken)
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/sopt/geonppang/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/home/HomeFragment.kt
@@ -2,13 +2,11 @@ package com.sopt.geonppang.presentation.home
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.sopt.geonppang.R
-import com.sopt.geonppang.data.datasource.local.GPDataSource
 import com.sopt.geonppang.databinding.FragmentHomeBinding
 import com.sopt.geonppang.presentation.detail.DetailActivity
 import com.sopt.geonppang.presentation.detail.DetailActivity.Companion.SOURCE
@@ -39,9 +37,6 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         initLayout()
         addListeners()
         collectData()
-
-        Log.d("access token", GPDataSource(requireActivity()).accessToken)
-        Log.d("refresh token", GPDataSource(requireActivity()).refreshToken)
     }
 
     override fun onResume() {


### PR DESCRIPTION
## Related issue 🛠
- closed #173 

## Work Description ✏️
- 카카오로 회원가입 시 서버에서 내려주는 응답 헤더값을 자체 디비에 저장합니다.

## To Reviewers 📢
재발급 이슈를 발견했고, 이를 저장하지 않는다는 것을 알아서 추가 구현했습니다