### PR TITLE
[fix] 토큰 재발급 후 api header에 리프레시 토큰이 추가되어 다시 재발급 되는 에러 해결

### DIFF
--- a/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/interceptor/AuthInterceptor.kt
@@ -47,7 +47,6 @@ class AuthInterceptor @Inject constructor(
                     refreshTokenResponse.close()
                     val newRequest = originalRequest.newBuilder()
                         .addHeader(ACCESS_TOKEN, gpDataSource.accessToken)
-                        .addHeader(REFRESH_TOKEN, gpDataSource.refreshToken)
                         .build()
                     return chain.proceed(newRequest)
                 } else {

--- a/app/src/main/java/com/sopt/geonppang/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/home/HomeViewModel.kt
@@ -30,8 +30,6 @@ class HomeViewModel @Inject constructor(
     val isFilterSelected get() = _isFilterSelected.asStateFlow()
 
     init {
-        fetchBestBakeryList()
-        fetchBestReviewList()
         getUserFilter()
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #178 

## Work Description ✏️
- 토큰 재발급 후 api header에 리프래시 토큰이 추가되어 일반 api를 요청하게 되면서, 서버에서 이를 재발급으로 인지해 유효한 토큰으로 재발급 되는 에러가 발생했고 이를 해결했습니다

## To Reviewers 📢
집 오니까 맑은 머리로 해결