### PR TITLE
[mod] 상세페이지 홈페이지, 인스타, 전화번호 없는 경우에 대한 분기처리, 상세페이지, 검색뷰, 필터뷰 이슈 해결

### DIFF
--- a/app/src/main/java/com/sopt/geonppang/data/model/response/ResponseDetailReview.kt
+++ b/app/src/main/java/com/sopt/geonppang/data/model/response/ResponseDetailReview.kt
@@ -33,7 +33,7 @@ data class ResponseDetailReview(
                 val recommendKeywordName: String
             )
 
-            fun toRecommentKeyword() = recommendKeywordList.map { recommendKeyword ->
+            fun toRecommendKeyword() = recommendKeywordList.map { recommendKeyword ->
                 DetailReview.RecommendKeyword(
                     recommendKeywordId = recommendKeyword.recommendKeywordId,
                     recommendKeywordName = recommendKeyword.recommendKeywordName
@@ -53,7 +53,7 @@ data class ResponseDetailReview(
                     memberNickname = review.memberNickname,
                     reviewId = review.reviewId,
                     reviewText = review.reviewText,
-                    recommendKeywordList = review.toRecommentKeyword()
+                    recommendKeywordList = review.toRecommendKeyword()
                 )
             }
         )

--- a/app/src/main/java/com/sopt/geonppang/presentation/common/BakeryAdapter.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/common/BakeryAdapter.kt
@@ -8,13 +8,14 @@ import com.google.android.material.chip.ChipGroup
 import com.sopt.geonppang.R
 import com.sopt.geonppang.databinding.ItemBakeryBinding
 import com.sopt.geonppang.domain.model.BakeryInformation
+import com.sopt.geonppang.presentation.type.BreadFilterType
 import com.sopt.geonppang.util.ItemDiffCallback
 import com.sopt.geonppang.util.extension.loadingImage
 import com.sopt.geonppang.util.extension.setOnSingleClickListener
 
 class BakeryAdapter(
     private val moveToDetail: (Int) -> Unit,
-    private val initBreadTypeChips: (ChipGroup, Int) -> Unit,
+    private val initBreadTypeChips: (ChipGroup, List<BreadFilterType>) -> Unit,
 ) : ListAdapter<BakeryInformation, BakeryAdapter.BakeryViewHolder>(
     ItemDiffCallback<BakeryInformation>(
         onItemsTheSame = { old, new -> old.bakeryId == new.bakeryId },
@@ -28,8 +29,7 @@ class BakeryAdapter(
         fun onBind(
             bakery: BakeryInformation,
             moveToDetail: (Int) -> Unit,
-            initBreadTypeChips: (ChipGroup, Int) -> Unit,
-            position: Int
+            initBreadTypeChips: (ChipGroup, List<BreadFilterType>) -> Unit
         ) {
             binding.bakery = bakery
             binding.executePendingBindings()
@@ -37,7 +37,7 @@ class BakeryAdapter(
             // TODO: dana 다른 방식이 있는지 고민, 매 바인딩마다 removeAllViews 해야하는가 ?
             with(binding.cgBakeryBreadTypes) {
                 this.removeAllViews()
-                initBreadTypeChips(this, position)
+                initBreadTypeChips(this, bakery.breadTypeList)
             }
 
             binding.root.setOnSingleClickListener {
@@ -59,6 +59,6 @@ class BakeryAdapter(
     }
 
     override fun onBindViewHolder(holder: BakeryViewHolder, position: Int) {
-        holder.onBind(getItem(position), moveToDetail, initBreadTypeChips, position)
+        holder.onBind(getItem(position), moveToDetail, initBreadTypeChips)
     }
 }

--- a/app/src/main/java/com/sopt/geonppang/presentation/detail/DetailBakeryInfoAdapter.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/detail/DetailBakeryInfoAdapter.kt
@@ -24,7 +24,10 @@ class DetailBakeryInfoAdapter(
             with(binding) {
                 binding.bakeryInfo = bakeryInfo
 
-                initBreadTypeChips(binding.chipGroupItemDetailBakeryInfoBreadType)
+                with(binding.chipGroupItemDetailBakeryInfoBreadType) {
+                    this.removeAllViews()
+                    initBreadTypeChips(this)
+                }
 
                 tvItemDetailBakeryInfoHomepage.setOnClickListener {
                     AmplitudeUtils.trackEvent(CLICK_WEBSITE)

--- a/app/src/main/java/com/sopt/geonppang/presentation/filterSetting/MainPurposeTypeFilterFragment.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/filterSetting/MainPurposeTypeFilterFragment.kt
@@ -25,12 +25,9 @@ class MainPurposeTypeFilterFragment :
     }
 
     private fun addListeners() {
-        binding.layoutMainPurposeTypeFilterSkip.setOnClickListener {
-            moveToMain()
-        }
-
-        binding.tvMainPurposeTypeFilterSkip.setOnSingleClickListener {
+        binding.layoutMainPurposeTypeFilterSkip.setOnSingleClickListener {
             AmplitudeUtils.trackEvent(CLICK_SKIP)
+            moveToMain()
         }
     }
 

--- a/app/src/main/java/com/sopt/geonppang/presentation/myPage/MyBookMarksActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/myPage/MyBookMarksActivity.kt
@@ -13,6 +13,7 @@ import com.sopt.geonppang.presentation.common.BakeryAdapter
 import com.sopt.geonppang.presentation.detail.DetailActivity
 import com.sopt.geonppang.presentation.detail.DetailActivity.Companion.SOURCE
 import com.sopt.geonppang.presentation.detail.DetailActivity.Companion.VIEW_DETAIL_PAGE_AT
+import com.sopt.geonppang.presentation.type.BreadFilterType
 import com.sopt.geonppang.util.AmplitudeUtils
 import com.sopt.geonppang.util.CustomItemDecoration
 import com.sopt.geonppang.util.UiState
@@ -85,17 +86,16 @@ class MyBookMarksActivity :
         startActivity(intent)
     }
 
-    private fun initBreadTypeChips(chipGroup: ChipGroup, position: Int) {
-        if (myBookMarkBakeryList.isNotEmpty()) {
-            myBookMarkBakeryList.get(position).breadTypeList.let { breadTypeList ->
-                chipGroup.breadTypeListToChips(
-                    breadTypeList = breadTypeList,
-                    toChip = {
-                        this.toBreadTypePointM2Chip(layoutInflater)
-                    }
-                )
+    private fun initBreadTypeChips(
+        chipGroup: ChipGroup,
+        breadTypeList: List<BreadFilterType>
+    ) {
+        chipGroup.breadTypeListToChips(
+            breadTypeList = breadTypeList,
+            toChip = {
+                this.toBreadTypePointM2Chip(layoutInflater)
             }
-        }
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/sopt/geonppang/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/search/SearchActivity.kt
@@ -11,11 +11,11 @@ import androidx.recyclerview.widget.ConcatAdapter
 import com.google.android.material.chip.ChipGroup
 import com.sopt.geonppang.R
 import com.sopt.geonppang.databinding.ActivitySearchBinding
-import com.sopt.geonppang.domain.model.BakeryInformation
 import com.sopt.geonppang.presentation.common.BakeryAdapter
 import com.sopt.geonppang.presentation.detail.DetailActivity
 import com.sopt.geonppang.presentation.detail.DetailActivity.Companion.SOURCE
 import com.sopt.geonppang.presentation.detail.DetailActivity.Companion.VIEW_DETAIL_PAGE_AT
+import com.sopt.geonppang.presentation.type.BreadFilterType
 import com.sopt.geonppang.util.AmplitudeUtils
 import com.sopt.geonppang.util.CustomItemDecoration
 import com.sopt.geonppang.util.UiState
@@ -33,8 +33,6 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
 
     private lateinit var bakeryAdapter: BakeryAdapter
     private lateinit var searchCountAdapter: SearchCountAdapter
-
-    private var bakeryInformationList = listOf<BakeryInformation>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -86,8 +84,6 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
                     completeFilteringInParticularView()
                     viewModel.searchBakeryList()
                     searchCountAdapter.setSearchData(it.data)
-
-                    bakeryInformationList = it.data.bakeryList
                     bakeryAdapter.submitList(it.data.bakeryList)
                 }
 
@@ -129,17 +125,16 @@ class SearchActivity : BindingActivity<ActivitySearchBinding>(R.layout.activity_
         return super.dispatchTouchEvent(ev)
     }
 
-    private fun initBreadTypeChips(chipGroup: ChipGroup, position: Int) {
-        if (bakeryInformationList.isNotEmpty()) {
-            bakeryInformationList.get(position).breadTypeList.let { breadTypeIdList ->
-                chipGroup.breadTypeListToChips(
-                    breadTypeList = breadTypeIdList,
-                    toChip = {
-                        this.toBreadTypePointM2Chip(layoutInflater)
-                    }
-                )
+    private fun initBreadTypeChips(
+        chipGroup: ChipGroup,
+        breadTypeList: List<BreadFilterType>
+    ) {
+        chipGroup.breadTypeListToChips(
+            breadTypeList = breadTypeList,
+            toChip = {
+                this.toBreadTypePointM2Chip(layoutInflater)
             }
-        }
+        )
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_main_purpose_type_filter.xml
+++ b/app/src/main/res/layout/fragment_main_purpose_type_filter.xml
@@ -123,6 +123,7 @@
                         android:textColor="@color/gray_500"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toStartOf="@+id/iv_main_purpose_type_filter_skip"
+                        app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
 
                     <ImageView

--- a/app/src/main/res/layout/item_bakery.xml
+++ b/app/src/main/res/layout/item_bakery.xml
@@ -139,8 +139,8 @@
 
         <TextView
             android:id="@+id/tv_nearest_station"
-            android:layout_width="72dp"
-            android:layout_height="17dp"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
             android:text="@{bakery.secondNearStation.empty ? bakery.firstNearStation : @string/nearest_station(bakery.firstNearStation, bakery.secondNearStation)}"
             android:textAppearance="@style/TextAppearance.CaptionM1"

--- a/app/src/main/res/layout/item_detail_bakery_info.xml
+++ b/app/src/main/res/layout/item_detail_bakery_info.xml
@@ -228,7 +228,7 @@
 
             <TextView
                 android:id="@+id/tv_item_detail_bakery_info_homepage"
-                visibility="@{!bakeryInfo.homepageUrl.isEmpty()}"
+                visibility="@{!bakeryInfo.homepageUrl.trim().isEmpty()}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
@@ -244,7 +244,7 @@
 
             <TextView
                 android:id="@+id/tv_item_detail_bakery_info_instagram"
-                visibility="@{!bakeryInfo.instagramUrl.isEmpty()}"
+                visibility="@{!bakeryInfo.instagramUrl.trim().isEmpty()}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"

--- a/app/src/main/res/layout/item_detail_bakery_info.xml
+++ b/app/src/main/res/layout/item_detail_bakery_info.xml
@@ -108,7 +108,7 @@
             app:chipSpacingHorizontal="4dp"
             app:layout_constraintEnd_toEndOf="@+id/tv_item_detail_bakery_info_bakery_name"
             app:layout_constraintStart_toStartOf="@+id/tv_item_detail_bakery_info_bakery_name"
-            app:layout_constraintTop_toBottomOf="@id/tv_item_detail_bakery_info_bakery_name"/>
+            app:layout_constraintTop_toBottomOf="@id/tv_item_detail_bakery_info_bakery_name" />
 
         <ImageView
             android:id="@+id/iv_item_detail_bakery_info_bookmark"
@@ -338,39 +338,27 @@
             app:layout_constraintTop_toBottomOf="@+id/tv_item_detail_bakery_info_time_holiday"
             tools:text="수-금 12:00 ~ 19:00 / 토-일 13:00 ~ 19:00 " />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_item_detail_bakery_info_call"
-            visibility="@{!bakeryInfo.phoneNumber.isEmpty()}"
-            android:layout_width="0dp"
+        <ImageView
+            android:id="@+id/iv_item_detail_bakery_info_call"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingTop="@dimen/spacing16"
-            app:layout_constraintEnd_toStartOf="@+id/gl_end"
+            android:layout_marginTop="@dimen/spacing16"
+            android:src="@drawable/ic_call"
             app:layout_constraintStart_toStartOf="@+id/gl_start"
-            app:layout_constraintTop_toBottomOf="@+id/tv_item_detail_bakery_info_time">
+            app:layout_constraintTop_toBottomOf="@+id/tv_item_detail_bakery_info_time" />
 
-            <ImageView
-                android:id="@+id/iv_item_detail_bakery_info_call"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_call"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/tv_item_detail_bakery_info_call"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="12dp"
-                android:text="@{bakeryInfo.phoneNumber}"
-                android:textAppearance="@style/TextAppearance.Subhead"
-                android:textColor="@color/gray_400"
-                app:layout_constraintBottom_toBottomOf="@+id/iv_item_detail_bakery_info_call"
-                app:layout_constraintStart_toEndOf="@+id/iv_item_detail_bakery_info_call"
-                app:layout_constraintTop_toTopOf="@+id/iv_item_detail_bakery_info_call"
-                tools:text="02-033-3333" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/tv_item_detail_bakery_info_call"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:text="@{bakeryInfo.phoneNumber}"
+            android:textAppearance="@style/TextAppearance.Subhead"
+            android:textColor="@color/gray_400"
+            app:layout_constraintBottom_toBottomOf="@+id/iv_item_detail_bakery_info_call"
+            app:layout_constraintStart_toEndOf="@+id/iv_item_detail_bakery_info_call"
+            app:layout_constraintTop_toTopOf="@+id/iv_item_detail_bakery_info_call"
+            tools:text="02-033-3333" />
 
         <View
             android:id="@+id/view_item_detail_bakery_info_second_line"
@@ -380,7 +368,7 @@
             android:background="@color/gray_200"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_item_detail_bakery_info_call" />
+            app:layout_constraintTop_toBottomOf="@id/iv_item_detail_bakery_info_call" />
 
         <TextView
             android:id="@+id/tv_item_detail_bakery_info_menu"


### PR DESCRIPTION
## Related issue 🛠
- closed #226 

## Work Description ✏️
- 상세페이지 홈페이지, 인스타, 전화번호가 없는 경우에 대한 분기처리를 진행하였습니다.
- 검색 뷰 관련 오류를 해결하였습니다. (item_bakery에서 역이 완전히 표시되지 않는 오류, 검색 2번 진행 시 앱이 터지는 오류)
- 상세페이지 관련 오류를 해결하였습니다. (북마크 클릭 시 칩이 계속 쌓이는 오류)
- 필터뷰 건너뛰기 터치영역 조절

## Screenshot 📸
- 검색 및 상세페이지 분기처리

https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/103172971/7ca53882-03af-4557-a6a4-3c9f87acf46a

- 북마크

https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/103172971/b7935f0f-9b68-40db-b268-9c4725ef1670

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
- 지금 영상에는 전화번호 없는 경우에 빈 값이 뜨는데 이거 실제 더미 쌓을 때 - 로 넣어주신다고 하셨습니다. (홈페이지, 인스타가 없는 경우 -> " " 내려줌 + 뷰에서 사라지도록 구현, 전화번호 없는 경우 -> - 내려줌 + 뷰에 - 표시)
- 하다가 북마크 클릭했을 때 칩이 계속 쌓이는 오류를 발견해서 그것도 고쳤어요 ~ (사진 참고 ㅋ.ㅋ)
<img width="249" alt="스크린샷 2024-02-18 오후 5 32 40" src="https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/103172971/56f95d09-c3b8-4698-881a-da792f660567">

- initBreadTypeChips 함수 확장함수로 빼는 게 나을지 고민하다가 그냥 놔뒀는데,, 뭐가 나은 것 같으신가요,,?