### PR TITLE
[mod] 비회원이 내 필터를 클릭하면 로그인 유도 바텀 시트를 띄우도록 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         applicationId "com.sopt.geonppang"
         minSdk 28
         targetSdk 34
-        versionCode 5
+        versionCode 6
         versionName "1.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/sopt/geonppang/domain/model/BakeryListFilterType.kt
+++ b/app/src/main/java/com/sopt/geonppang/domain/model/BakeryListFilterType.kt
@@ -4,7 +4,7 @@ import com.sopt.geonppang.presentation.type.BakerySortType
 
 data class BakeryListFilterType(
     val sortType: BakerySortType = BakerySortType.DEFAULT,
-    val isPersonalFilterApplied: Boolean? = null,
+    val isPersonalFilterApplied: Boolean,
     val isHard: Boolean = false,
     val isDessert: Boolean = false,
     val isBrunch: Boolean = false

--- a/app/src/main/java/com/sopt/geonppang/presentation/bakeryList/BakeryListFragment.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/bakeryList/BakeryListFragment.kt
@@ -61,12 +61,13 @@ class BakeryListFragment :
 
         val isFilterSelectedMember =
             bakeryListViewModel.userRoleType.value == UserRoleType.FILTER_SELECTED_MEMBER.name
+        val isNoneMember = bakeryListViewModel.userRoleType.value == UserRoleType.NONE_MEMBER.name
 
         with(binding) {
             includeHomeSpeechBubble.root.setVisibility(bakeryListViewModel.userRoleType.value == UserRoleType.FILTER_UNSELECTED_MEMBER.name)
             checkBakeryListMyFilter.isEnabled = isFilterSelectedMember
             checkBakeryListMyFilter.isChecked = isFilterSelectedMember
-            layoutBakeryListMyFiltaerApply.isEnabled = isFilterSelectedMember
+            layoutBakeryListMyFilterApply.isEnabled = isFilterSelectedMember or isNoneMember
         }
     }
 
@@ -141,6 +142,12 @@ class BakeryListFragment :
                 }
             }
             .launchIn(viewLifecycleOwner.lifecycleScope)
+
+        bakeryListViewModel.showLoginNeed.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach {
+            if (it) {
+                showLoginNeedDialog()
+            }
+        }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
     private fun initBreadTypeChips(chipGroup: ChipGroup, breadFilterList: List<BreadFilterType>) {

--- a/app/src/main/java/com/sopt/geonppang/presentation/bakeryList/BakeryListViewModel.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/bakeryList/BakeryListViewModel.kt
@@ -23,14 +23,15 @@ class BakeryListViewModel @Inject constructor(
     private val bakeryListPagingRepository: BakeryListPagingRepository,
     private val gpDataSource: GPDataSource
 ) : ViewModel() {
-    private var _bakeryListFilterState = MutableStateFlow(BakeryListFilterType())
+    private var _bakeryListFilterState = MutableStateFlow(
+        BakeryListFilterType(
+            isPersonalFilterApplied = gpDataSource.userRoleType == UserRoleType.FILTER_SELECTED_MEMBER.name
+        )
+    )
     val bakeryListFilterType get() = _bakeryListFilterState.asStateFlow()
 
     private val _userRoleType = MutableStateFlow(gpDataSource.userRoleType)
     val userRoleType get() = _userRoleType
-
-    private val _showLoginNeed = MutableStateFlow(false)
-    val showLoginNeed get() = _showLoginNeed
 
     fun setBakerySortType(bakerySortType: BakerySortType) {
         _bakeryListFilterState.update {
@@ -40,12 +41,8 @@ class BakeryListViewModel @Inject constructor(
 
     // TODO: dana update 로직 수정 필요
     fun setIsPersonalFilterAppliedState() {
-        if (_userRoleType.value == UserRoleType.NONE_MEMBER.name) {
-            _showLoginNeed.value = true
-        } else {
-            _bakeryListFilterState.update {
-                it.copy(isPersonalFilterApplied = it.isPersonalFilterApplied == false)
-            }
+        _bakeryListFilterState.update {
+            it.copy(isPersonalFilterApplied = !it.isPersonalFilterApplied)
         }
     }
 

--- a/app/src/main/java/com/sopt/geonppang/presentation/bakeryList/BakeryListViewModel.kt
+++ b/app/src/main/java/com/sopt/geonppang/presentation/bakeryList/BakeryListViewModel.kt
@@ -10,6 +10,7 @@ import com.sopt.geonppang.domain.model.BakeryInformation
 import com.sopt.geonppang.domain.model.BakeryListFilterType
 import com.sopt.geonppang.presentation.type.BakeryCategoryType
 import com.sopt.geonppang.presentation.type.BakerySortType
+import com.sopt.geonppang.presentation.type.UserRoleType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,6 +29,9 @@ class BakeryListViewModel @Inject constructor(
     private val _userRoleType = MutableStateFlow(gpDataSource.userRoleType)
     val userRoleType get() = _userRoleType
 
+    private val _showLoginNeed = MutableStateFlow(false)
+    val showLoginNeed get() = _showLoginNeed
+
     fun setBakerySortType(bakerySortType: BakerySortType) {
         _bakeryListFilterState.update {
             it.copy(sortType = bakerySortType)
@@ -36,8 +40,12 @@ class BakeryListViewModel @Inject constructor(
 
     // TODO: dana update 로직 수정 필요
     fun setIsPersonalFilterAppliedState() {
-        _bakeryListFilterState.update {
-            it.copy(isPersonalFilterApplied = it.isPersonalFilterApplied == false)
+        if (_userRoleType.value == UserRoleType.NONE_MEMBER.name) {
+            _showLoginNeed.value = true
+        } else {
+            _bakeryListFilterState.update {
+                it.copy(isPersonalFilterApplied = it.isPersonalFilterApplied == false)
+            }
         }
     }
 

--- a/app/src/main/res/layout/fragment_bakery_list.xml
+++ b/app/src/main/res/layout/fragment_bakery_list.xml
@@ -149,7 +149,7 @@
             app:layout_constraintTop_toBottomOf="@id/view_line_bottom">
 
             <LinearLayout
-                android:id="@+id/layout_bakery_list_my_filtaer_apply"
+                android:id="@+id/layout_bakery_list_my_filter_apply"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing24"

--- a/app/src/main/res/layout/fragment_bakery_list.xml
+++ b/app/src/main/res/layout/fragment_bakery_list.xml
@@ -153,7 +153,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing24"
-                android:onClick="@{() -> viewModel.setIsPersonalFilterAppliedState()}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
@@ -163,7 +162,9 @@
                     style="@style/Style.CheckBox"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:onClick="@{() -> viewModel.setIsPersonalFilterAppliedState()}" />
+                    android:checked="@{viewModel.bakeryListFilterType.personalFilterApplied}"
+                    android:clickable="false"
+                    android:focusable="false" />
 
                 <TextView
                     android:layout_width="wrap_content"


### PR DESCRIPTION
## Related issue 🛠
- closed #233 

## Work Description ✏️
- 로그인 바텀 시트 띄우기

## Screenshot 📸
<img src="" width="360"/>

https://github.com/GEON-PPANG/GEON-PPANG-AOS/assets/61531386/4cf7b581-57ab-409d-b0db-1a706cb47866



## Uncompleted Tasks 😅
- [ ] 

## To Reviewers 📢

바인딩으로 setIsPersonalFilterAppliedState()를 호출하고 있어서 프래그먼트를  init 했을 때마다 적용이 되고 

발견한 문제도 마찬가지로 바인딩으로 호출하고 내 필터 타입 첫 상태가 null 이어서 그런지 원하는 형태로 바꾸기가 쉽지 않군요! ㅜ
이걸 고민하다가 조금 오래걸렸는데.. 해결을 못하고 pr 올립니다
```
data class BakeryListFilterType(
    val sortType: BakerySortType = BakerySortType.DEFAULT,
    val isPersonalFilterApplied: Boolean? = null,
    val isHard: Boolean = false,
    val isDessert: Boolean = false,
    val isBrunch: Boolean = false
)
```

다은 수정사항!
문제 상황 1. 필터 적용 회원일 때, 건빵집 리스트를 최초에 진입했을 시 필터 적용이 안되어 있음
원인: fragment 생성 시, 내 필터 적용 초기값이 null
해결: userRoleType에 따라 true, false로 초기값을 지정(필터 적용 회원일 때 초기값이 true가 되도록)

문제 상황, 원인 2. 비회원 일 시, 체크박스가 enable하지 않아 클릭 리스너가 먹히지 않아 로그인 유도 바텀 시트가 눌리지 않는 상황
헤결: 체크 박스 자체에 클릭, 포커스 속성을 없앰. 체크박스와 내 필터 적용 텍스트를 감싸는 레이아웃만 포커스를 주기 위해!
따라서 레이아웃을 눌렀을 때 UserRoleType에 따른 분기처리를 진행했고 체크 박스에 체크 표시는 isPersonalFilterApplied 속성에 따라 조절되게 함! 누르는 행위로 인해 체크 상태가 바뀌는게 아닌!